### PR TITLE
Loosen version constraints for sprockets

### DIFF
--- a/sprockets-media_query_combiner.gemspec
+++ b/sprockets-media_query_combiner.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.2'
 
-  gem.add_runtime_dependency "sprockets", "~>2.1.3"
+  gem.add_runtime_dependency "sprockets", "~>2.1"
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Allows upgrade to rails 3.2.11
