### PR TITLE
Use ::Rails instead of Rails

### DIFF
--- a/lib/sprockets/media_query_combiner/engine.rb
+++ b/lib/sprockets/media_query_combiner/engine.rb
@@ -1,9 +1,9 @@
 require 'sprockets/media_query_combiner/processor'
 
-if defined?(Rails)
+if defined?(::Rails)
   module Sprockets
     module MediaQueryCombiner
-      class Engine < Rails::Engine
+      class Engine < ::Rails::Engine
         initializer :setup_media_query_combiner, after: 'sprockets.environment', group: :all do |app|
           app.assets.register_postprocessor 'text/css', Sprockets::MediaQueryCombiner::Processor
           app.assets.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor


### PR DESCRIPTION
Prevents Rails 4 Rake error: uninitialized constant Sprockets::Rails::Engine
