### PR TITLE
Sprockets3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
+ - 1.9
  - 2.2
- - jruby
  - rbx-2
 before_install:
  - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+ - 2.2
+ - jruby
+ - rbx-2
+before_install:
+ - gem update bundler

--- a/lib/sprockets/media_query_combiner/engine.rb
+++ b/lib/sprockets/media_query_combiner/engine.rb
@@ -5,8 +5,9 @@ if defined?(::Rails)
     module MediaQueryCombiner
       class Engine < ::Rails::Engine
         initializer :setup_media_query_combiner, after: 'sprockets.environment', group: :all do |app|
-          app.assets.register_postprocessor 'text/css', Sprockets::MediaQueryCombiner::Processor
-          app.assets.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor
+          sprockets_env = app.assets || Sprockets
+          sprockets_env.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor
+          sprockets_env.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor
         end
       end
     end

--- a/lib/sprockets/media_query_combiner/engine.rb
+++ b/lib/sprockets/media_query_combiner/engine.rb
@@ -3,14 +3,12 @@ require 'sprockets/media_query_combiner/processor'
 if defined?(::Rails)
   module Sprockets
     module MediaQueryCombiner
-      
       class Engine < ::Rails::Engine
         initializer :setup_media_query_combiner, after: 'sprockets.environment', group: :all do |app|
-          Sprockets.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor
+          Sprockets.register_postprocessor 'text/css', Sprockets::MediaQueryCombiner::Processor
           Sprockets.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor
         end
       end
-
     end
   end
 end

--- a/lib/sprockets/media_query_combiner/engine.rb
+++ b/lib/sprockets/media_query_combiner/engine.rb
@@ -7,8 +7,8 @@ if defined?(::Rails)
       class Engine < ::Rails::Engine
         initializer :setup_media_query_combiner, after: 'sprockets.environment', group: :all do |app|        
           sprockets_env = app.assets || Sprockets
-          sprockets_env.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor.choose_processor
-          sprockets_env.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor.choose_processor
+          sprockets_env.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor.choose
+          sprockets_env.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor.choose
         end
       end
 

--- a/lib/sprockets/media_query_combiner/engine.rb
+++ b/lib/sprockets/media_query_combiner/engine.rb
@@ -5,11 +5,9 @@ if defined?(::Rails)
     module MediaQueryCombiner
       
       class Engine < ::Rails::Engine
-        initializer :setup_media_query_combiner, after: 'sprockets.environment', group: :all do |app|        
-          # support for all Sprockets versions (up to 4.X)
-          sprockets_env = app.assets || Sprockets
-          sprockets_env.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor
-          sprockets_env.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor
+        initializer :setup_media_query_combiner, after: 'sprockets.environment', group: :all do |app|
+          Sprockets.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor
+          Sprockets.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor
         end
       end
 

--- a/lib/sprockets/media_query_combiner/engine.rb
+++ b/lib/sprockets/media_query_combiner/engine.rb
@@ -3,13 +3,15 @@ require 'sprockets/media_query_combiner/processor'
 if defined?(::Rails)
   module Sprockets
     module MediaQueryCombiner
+      
       class Engine < ::Rails::Engine
-        initializer :setup_media_query_combiner, after: 'sprockets.environment', group: :all do |app|
+        initializer :setup_media_query_combiner, after: 'sprockets.environment', group: :all do |app|        
           sprockets_env = app.assets || Sprockets
-          sprockets_env.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor
-          sprockets_env.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor
+          sprockets_env.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor.choose_processor
+          sprockets_env.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor.choose_processor
         end
       end
+
     end
   end
 end

--- a/lib/sprockets/media_query_combiner/engine.rb
+++ b/lib/sprockets/media_query_combiner/engine.rb
@@ -8,8 +8,8 @@ if defined?(::Rails)
         initializer :setup_media_query_combiner, after: 'sprockets.environment', group: :all do |app|        
           # support for all Sprockets versions (up to 4.X)
           sprockets_env = app.assets || Sprockets
-          sprockets_env.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor.choose
-          sprockets_env.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor.choose
+          sprockets_env.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor
+          sprockets_env.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor
         end
       end
 

--- a/lib/sprockets/media_query_combiner/engine.rb
+++ b/lib/sprockets/media_query_combiner/engine.rb
@@ -6,6 +6,7 @@ if defined?(::Rails)
       
       class Engine < ::Rails::Engine
         initializer :setup_media_query_combiner, after: 'sprockets.environment', group: :all do |app|        
+          # support for all Sprockets versions (up to 4.X)
           sprockets_env = app.assets || Sprockets
           sprockets_env.register_postprocessor    'text/css', Sprockets::MediaQueryCombiner::Processor.choose
           sprockets_env.register_bundle_processor 'text/css', Sprockets::MediaQueryCombiner::Processor.choose

--- a/lib/sprockets/media_query_combiner/processor.rb
+++ b/lib/sprockets/media_query_combiner/processor.rb
@@ -1,15 +1,13 @@
-require 'tilt'
 require 'sass/media_query_combiner/combiner'
 
 module Sprockets
   module MediaQueryCombiner
-    class Processor < Tilt::Template
-      def prepare
+    class Processor
+      
+      def self.call(input)
+        Sass::MediaQueryCombiner::Combiner.combine(input)
       end
 
-      def evaluate(context, locals, &block)
-        Sass::MediaQueryCombiner::Combiner.combine(data)
-      end
     end
   end
 end

--- a/lib/sprockets/media_query_combiner/processor.rb
+++ b/lib/sprockets/media_query_combiner/processor.rb
@@ -1,29 +1,18 @@
+require 'sprockets'
 require 'sass/media_query_combiner/combiner'
 
 module Sprockets
   module MediaQueryCombiner
-    
-    # serves to pick proper processor
-    class Processor
-      # returns processor class valid for current Sprockets version
-      def self.choose
-        return SprocketsProcessor if Sprockets.respond_to? :register_postprocessor
-        TiltProcessor
-      end
-    end
 
-    # for Sprockets >= 3.X
-    class SprocketsProcessor
-      def self.call(input)
-        Sass::MediaQueryCombiner::Combiner.combine input[:data]
+    if Sprockets::VERSION[0,1].to_i >= 3
+      class Processor
+        def self.call(input)
+          Sass::MediaQueryCombiner::Combiner.combine input[:data]
+        end
       end
-    end
-
-    # support for older Sprockets versions (<3.X)
-    begin
+    else # support for ancient Sprockets
       require 'tilt'
-
-      class TiltProcessor < Tilt::Template
+      class Processor < Tilt::Template
         def prepare
         end
 
@@ -31,9 +20,6 @@ module Sprockets
           Sass::MediaQueryCombiner::Combiner.combine data
         end
       end
-    
-    rescue LoadError
-      STDOUT.puts "Using native Sprockets processor"
     end
 
   end

--- a/lib/sprockets/media_query_combiner/processor.rb
+++ b/lib/sprockets/media_query_combiner/processor.rb
@@ -2,25 +2,10 @@ require 'sass/media_query_combiner/combiner'
 
 module Sprockets
   module MediaQueryCombiner
-
-    spec = Gem::Specification.find_by_name 'sprockets'
-    if spec.version.to_s[0,1].to_i >= 3
-      class Processor
-        def self.call(input)
-          Sass::MediaQueryCombiner::Combiner.combine input[:data]
-        end
-      end
-    else # support for ancient Sprockets
-      require 'tilt'
-      class Processor < Tilt::Template
-        def prepare
-        end
-
-        def evaluate(context, locals, &block)
-          Sass::MediaQueryCombiner::Combiner.combine data
-        end
+    class Processor
+      def self.call(input)
+        Sass::MediaQueryCombiner::Combiner.combine input[:data]
       end
     end
-
   end
 end

--- a/lib/sprockets/media_query_combiner/processor.rb
+++ b/lib/sprockets/media_query_combiner/processor.rb
@@ -1,13 +1,29 @@
+require 'tilt' unless Sprockets.respond_to? :register_postprocessor
 require 'sass/media_query_combiner/combiner'
 
 module Sprockets
   module MediaQueryCombiner
+
     class Processor
-      
+      def self.choose_processor
+        return self if Sprockets.respond_to? :register_postprocessor
+        TiltProcessor
+      end
       def self.call(input)
-        Sass::MediaQueryCombiner::Combiner.combine(input)
+        STDOUT.puts "*"*100 + "Sprockets Processor"
+        Sass::MediaQueryCombiner::Combiner.combine input[:data]
+      end
+    end
+
+    class TiltProcessor < Tilt::Template
+      def prepare
       end
 
+      def evaluate(context, locals, &block)
+        STDOUT.puts "*"*100 + "Tilt Processor"
+        Sass::MediaQueryCombiner::Combiner.combine data
+      end
     end
+
   end
 end

--- a/lib/sprockets/media_query_combiner/processor.rb
+++ b/lib/sprockets/media_query_combiner/processor.rb
@@ -3,21 +3,24 @@ require 'sass/media_query_combiner/combiner'
 module Sprockets
   module MediaQueryCombiner
     
+    # serves to pick proper processor
     class Processor
+      # returns processor class valid for current Sprockets version
       def self.choose
         return SprocketsProcessor if Sprockets.respond_to? :register_postprocessor
         TiltProcessor
       end
     end
 
+    # for Sprockets >= 3.X
     class SprocketsProcessor
       def self.call(input)
-        STDOUT.puts "*"*100 + "Sprockets Processor"
         Sass::MediaQueryCombiner::Combiner.combine input[:data]
       end
     end
 
-    begin    
+    # support for older Sprockets versions (<3.X)
+    begin
       require 'tilt'
 
       class TiltProcessor < Tilt::Template
@@ -25,7 +28,6 @@ module Sprockets
         end
 
         def evaluate(context, locals, &block)
-          STDOUT.puts "*"*100 + "Tilt Processor"
           Sass::MediaQueryCombiner::Combiner.combine data
         end
       end

--- a/lib/sprockets/media_query_combiner/processor.rb
+++ b/lib/sprockets/media_query_combiner/processor.rb
@@ -1,28 +1,37 @@
-require 'tilt' unless Sprockets.respond_to? :register_postprocessor
 require 'sass/media_query_combiner/combiner'
 
 module Sprockets
   module MediaQueryCombiner
-
+    
     class Processor
-      def self.choose_processor
-        return self if Sprockets.respond_to? :register_postprocessor
+      def self.choose
+        return SprocketsProcessor if Sprockets.respond_to? :register_postprocessor
         TiltProcessor
       end
+    end
+
+    class SprocketsProcessor
       def self.call(input)
         STDOUT.puts "*"*100 + "Sprockets Processor"
         Sass::MediaQueryCombiner::Combiner.combine input[:data]
       end
     end
 
-    class TiltProcessor < Tilt::Template
-      def prepare
-      end
+    begin    
+      require 'tilt'
 
-      def evaluate(context, locals, &block)
-        STDOUT.puts "*"*100 + "Tilt Processor"
-        Sass::MediaQueryCombiner::Combiner.combine data
+      class TiltProcessor < Tilt::Template
+        def prepare
+        end
+
+        def evaluate(context, locals, &block)
+          STDOUT.puts "*"*100 + "Tilt Processor"
+          Sass::MediaQueryCombiner::Combiner.combine data
+        end
       end
+    
+    rescue LoadError
+      STDOUT.puts "Using native Sprockets processor"
     end
 
   end

--- a/lib/sprockets/media_query_combiner/processor.rb
+++ b/lib/sprockets/media_query_combiner/processor.rb
@@ -1,10 +1,10 @@
-require 'sprockets'
 require 'sass/media_query_combiner/combiner'
 
 module Sprockets
   module MediaQueryCombiner
 
-    if Sprockets::VERSION[0,1].to_i >= 3
+    spec = Gem::Specification.find_by_name 'sprockets'
+    if spec.version.to_s[0,1].to_i >= 3
       class Processor
         def self.call(input)
           Sass::MediaQueryCombiner::Combiner.combine input[:data]

--- a/lib/sprockets/media_query_combiner/version.rb
+++ b/lib/sprockets/media_query_combiner/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module MediaQueryCombiner
-    VERSION = "0.0.8"
+    VERSION = "0.0.9"
   end
 end

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -1,3 +1,4 @@
+require 'sprockets'
 require 'spec_helper'
 require 'sprockets/media_query_combiner/processor'
 
@@ -56,46 +57,22 @@ CSS
   ugly_input_css = "h3{color:orange}@media (max-width:480px){h1{color:red}}@media (max-width:980px){h4{color:black}}@media (max-width:480px){h2{color:blue}}\n"
   ugly_target_css = "h3{color:orange}@media (max-width:480px){h1{color:red}h2{color:blue}}@media (max-width:980px){h4{color:black}}\n"
 
-  versions_to_test = [2, 3]
-  gem_spec = Gem::Specification.find_by_name 'sprockets'
-  init_version = gem_spec.version.to_s[0,1].to_i
-  
-  versions_to_test.each do |test_version|
 
-    # install Sprockets if necessary
-    if test_version != init_version
-      require 'rubygems/commands/install_command'
-      cmd = Gem::Commands::InstallCommand.new
-      cmd.handle_options ["--no-ri", "--no-rdoc", 'sprockets', '--version', "#{test_version}.6.0"]
-
-      begin
-        cmd.execute
-      rescue Gem::SystemExitException => e
-        puts "DONE: #{e.exit_code}"
-      end
-
-      puts "* using sprockets #{test_version}.6.0"
-      load 'sprockets'
+  output = 
+    if Sprockets::VERSION[0,1].to_i >= 3
+      lambda { |input| Processor.call( { data: input } ) }
+    else
+      lambda { |input| Processor.new { input }.evaluate(nil, nil) }
     end
 
-    output = 
-      if Sprockets::VERSION[0,1].to_i >= 3
-        lambda { |input| Processor.call( { data: input } ) }
-      else
-        lambda { |input| Processor.new { input }.evaluate(nil, nil) }
-      end
-
-    describe "Processor running with Sprockets #{test_version}" do
-      it "should work with pretty css" do
-        output[pretty_input_css].should == pretty_target_css
-      end
-
-      it "should work with ugly css" do
-        output[ugly_input_css].should == ugly_target_css
-      end
+  describe Processor do
+    it "should work with pretty css" do
+      output[pretty_input_css].should == pretty_target_css
     end
-    
+
+    it "should work with ugly css" do
+      output[ugly_input_css].should == ugly_target_css
+    end
   end
-
-
+    
 end

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -2,69 +2,77 @@ require 'spec_helper'
 require 'sprockets/media_query_combiner/processor'
 
 module Sprockets::MediaQueryCombiner
-  describe Processor do
+  pretty_input_css = <<CSS
+h3 {
+  color: orange
+}
+
+@media (max-width: 480px) {
+  h1 {
+    color: red
+  }
+}
+
+@media (max-width: 980px) {
+  h4 {
+    color: black
+  }
+}
+@media (max-width: 480px) {
+  h2 {
+    color: blue
+  }
+}
+
+b {
+  color: yellow
+}
+CSS
+  pretty_target_css = <<CSS
+h3 {
+  color: orange
+}
+
+b {
+  color: yellow
+}
+
+@media (max-width: 480px) {
+  h1 {
+    color: red
+  }
+
+  h2 {
+    color: blue
+  }
+}
+
+@media (max-width: 980px) {
+  h4 {
+    color: black
+  }
+}
+CSS
+  ugly_input_css = "h3{color:orange}@media (max-width:480px){h1{color:red}}@media (max-width:980px){h4{color:black}}@media (max-width:480px){h2{color:blue}}\n"
+  ugly_target_css = "h3{color:orange}@media (max-width:480px){h1{color:red}h2{color:blue}}@media (max-width:980px){h4{color:black}}\n"
+
+  handler = 
+    if Sprockets.respond_to? :register_postprocessor
+      result = lambda { |processor, input| processor.call(input) }
+      SprocketsProcessor
+    else
+      result = lambda { |processor, input| processor.new( { input } ).evaluate(nil, nil) }
+      TiltProcessor
+    end
+
+  describe handler do
     it "should work with pretty css" do
-      combiner = Processor.new do
-<<CSS
-h3 {
-  color: orange
-}
-
-@media (max-width: 480px) {
-  h1 {
-    color: red
-  }
-}
-
-@media (max-width: 980px) {
-  h4 {
-    color: black
-  }
-}
-@media (max-width: 480px) {
-  h2 {
-    color: blue
-  }
-}
-
-b {
-  color: yellow
-}
-CSS
-      end
-      combiner.evaluate(nil, nil).should == <<CSS
-h3 {
-  color: orange
-}
-
-b {
-  color: yellow
-}
-
-@media (max-width: 480px) {
-  h1 {
-    color: red
-  }
-
-  h2 {
-    color: blue
-  }
-}
-
-@media (max-width: 980px) {
-  h4 {
-    color: black
-  }
-}
-CSS
+      result[handler, pretty_input_css].should == pretty_target_css
     end
 
     it "should work with ugly css" do
-      combiner = Processor.new do
-        "h3{color:orange}@media (max-width:480px){h1{color:red}}@media (max-width:980px){h4{color:black}}@media (max-width:480px){h2{color:blue}}\n"
-      end
-      combiner.evaluate(nil, nil).should ==
-        "h3{color:orange}@media (max-width:480px){h1{color:red}h2{color:blue}}@media (max-width:980px){h4{color:black}}\n"
+      result[handler, ugly_input_css].should == ugly_target_css
     end
   end
+
 end

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -57,21 +57,47 @@ CSS
   ugly_input_css = "h3{color:orange}@media (max-width:480px){h1{color:red}}@media (max-width:980px){h4{color:black}}@media (max-width:480px){h2{color:blue}}\n"
   ugly_target_css = "h3{color:orange}@media (max-width:480px){h1{color:red}h2{color:blue}}@media (max-width:980px){h4{color:black}}\n"
 
-  output = 
-    if Sprockets::VERSION[0,1].to_i >= 3
-      lambda { |input| Processor.call( { data: input } ) }
-    else
-      lambda { |input| Processor.new { input }.evaluate(nil, nil) }
+  versions_to_test = [2, 3]
+  gem_spec = Gem::Specification.find_by_name 'sprockets'
+  v = gem_spec.version.to_s[0,1].to_i
+  
+  versions_to_test.each do |version|
+
+    # install Sprockets if necessary
+    if version != v
+      require 'rubygems/commands/install_command'
+      cmd = Gem::Commands::InstallCommand.new
+      cmd.handle_options ["--no-ri", "--no-rdoc", 'sprockets', '--version', "#{v}.6.0"]
+
+      begin
+        cmd.execute
+      rescue Gem::SystemExitException => e
+        puts "DONE: #{e.exit_code}"
+      end
+
+      puts "* using sprockets #{v}.6.0"
+      gem 'sprockets', "#{v}.6.0"
+      require 'sprockets'
     end
 
-  describe Processor do
-    it "should work with pretty css" do
-      output[pretty_input_css].should == pretty_target_css
-    end
+    output = 
+      if Sprockets::VERSION[0,1].to_i >= 3
+        lambda { |input| Processor.call( { data: input } ) }
+      else
+        lambda { |input| Processor.new { input }.evaluate(nil, nil) }
+      end
 
-    it "should work with ugly css" do
-      output[ugly_input_css].should == ugly_target_css
+    describe "Processor running with Sprockets #{version}" do
+      it "should work with pretty css" do
+        output[pretty_input_css].should == pretty_target_css
+      end
+
+      it "should work with ugly css" do
+        output[ugly_input_css].should == ugly_target_css
+      end
     end
+    
   end
+
 
 end

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -1,4 +1,3 @@
-require 'sprockets' # so we know which processor to use in tests
 require 'spec_helper'
 require 'sprockets/media_query_combiner/processor'
 
@@ -76,8 +75,7 @@ CSS
       end
 
       puts "* using sprockets #{test_version}.6.0"
-      gem 'sprockets', "#{test_version}.6.0"
-      require 'sprockets'
+      load 'sprockets'
     end
 
     output = 

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -1,3 +1,4 @@
+require 'sprockets' # so we know which processor to use in tests
 require 'spec_helper'
 require 'sprockets/media_query_combiner/processor'
 
@@ -58,20 +59,20 @@ CSS
 
   handler = 
     if Sprockets.respond_to? :register_postprocessor
-      result = lambda { |processor, input| processor.call(input) }
+      output = -> (input) { SprocketsProcessor.call(input) }
       SprocketsProcessor
     else
-      result = lambda { |processor, input| processor.new { input }.evaluate(nil, nil) }
+      output = -> (input) { TiltProcessor.new { input }.evaluate(nil, nil) }
       TiltProcessor
     end
 
   describe handler do
     it "should work with pretty css" do
-      result[handler, pretty_input_css].should == pretty_target_css
+      output[pretty_input_css].should == pretty_target_css
     end
 
     it "should work with ugly css" do
-      result[handler, ugly_input_css].should == ugly_target_css
+      output[ugly_input_css].should == ugly_target_css
     end
   end
 

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -61,7 +61,7 @@ CSS
       result = lambda { |processor, input| processor.call(input) }
       SprocketsProcessor
     else
-      result = lambda { |processor, input| processor.new( { input } ).evaluate(nil, nil) }
+      result = lambda { |processor, input| processor.new { input }.evaluate(nil, nil) }
       TiltProcessor
     end
 

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -69,5 +69,4 @@ CSS
       output[ugly_input_css].should == ugly_target_css
     end
   end
-    
 end

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -57,16 +57,14 @@ CSS
   ugly_input_css = "h3{color:orange}@media (max-width:480px){h1{color:red}}@media (max-width:980px){h4{color:black}}@media (max-width:480px){h2{color:blue}}\n"
   ugly_target_css = "h3{color:orange}@media (max-width:480px){h1{color:red}h2{color:blue}}@media (max-width:980px){h4{color:black}}\n"
 
-  handler = 
-    if Sprockets.respond_to? :register_postprocessor
-      output = lambda { |input| SprocketsProcessor.call( { data: input } ) }
-      SprocketsProcessor
+  output = 
+    if Sprockets::VERSION[0,1].to_i >= 3
+      lambda { |input| Processor.call( { data: input } ) }
     else
-      output = lambda { |input| TiltProcessor.new { input }.evaluate(nil, nil) }
-      TiltProcessor
+      lambda { |input| Processor.new { input }.evaluate(nil, nil) }
     end
 
-  describe handler do
+  describe Processor do
     it "should work with pretty css" do
       output[pretty_input_css].should == pretty_target_css
     end

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -59,7 +59,7 @@ CSS
 
   handler = 
     if Sprockets.respond_to? :register_postprocessor
-      output = -> (input) { SprocketsProcessor.call(input) }
+      output = -> (input) { SprocketsProcessor.call( { data: input } ) }
       SprocketsProcessor
     else
       output = -> (input) { TiltProcessor.new { input }.evaluate(nil, nil) }

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -59,10 +59,10 @@ CSS
 
   handler = 
     if Sprockets.respond_to? :register_postprocessor
-      output = -> (input) { SprocketsProcessor.call( { data: input } ) }
+      output = lambda { |input| SprocketsProcessor.call( { data: input } ) }
       SprocketsProcessor
     else
-      output = -> (input) { TiltProcessor.new { input }.evaluate(nil, nil) }
+      output = lambda { |input| TiltProcessor.new { input }.evaluate(nil, nil) }
       TiltProcessor
     end
 

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -59,15 +59,15 @@ CSS
 
   versions_to_test = [2, 3]
   gem_spec = Gem::Specification.find_by_name 'sprockets'
-  v = gem_spec.version.to_s[0,1].to_i
+  init_version = gem_spec.version.to_s[0,1].to_i
   
-  versions_to_test.each do |version|
+  versions_to_test.each do |test_version|
 
     # install Sprockets if necessary
-    if version != v
+    if test_version != init_version
       require 'rubygems/commands/install_command'
       cmd = Gem::Commands::InstallCommand.new
-      cmd.handle_options ["--no-ri", "--no-rdoc", 'sprockets', '--version', "#{v}.6.0"]
+      cmd.handle_options ["--no-ri", "--no-rdoc", 'sprockets', '--version', "#{test_version}.6.0"]
 
       begin
         cmd.execute
@@ -75,8 +75,8 @@ CSS
         puts "DONE: #{e.exit_code}"
       end
 
-      puts "* using sprockets #{v}.6.0"
-      gem 'sprockets', "#{v}.6.0"
+      puts "* using sprockets #{test_version}.6.0"
+      gem 'sprockets', "#{test_version}.6.0"
       require 'sprockets'
     end
 
@@ -87,7 +87,7 @@ CSS
         lambda { |input| Processor.new { input }.evaluate(nil, nil) }
       end
 
-    describe "Processor running with Sprockets #{version}" do
+    describe "Processor running with Sprockets #{test_version}" do
       it "should work with pretty css" do
         output[pretty_input_css].should == pretty_target_css
       end

--- a/spec/sprockets/media_query_combiner/processor_spec.rb
+++ b/spec/sprockets/media_query_combiner/processor_spec.rb
@@ -58,12 +58,7 @@ CSS
   ugly_target_css = "h3{color:orange}@media (max-width:480px){h1{color:red}h2{color:blue}}@media (max-width:980px){h4{color:black}}\n"
 
 
-  output = 
-    if Sprockets::VERSION[0,1].to_i >= 3
-      lambda { |input| Processor.call( { data: input } ) }
-    else
-      lambda { |input| Processor.new { input }.evaluate(nil, nil) }
-    end
+  output = lambda { |input| Processor.call( { data: input } ) }
 
   describe Processor do
     it "should work with pretty css" do

--- a/sprockets-media_query_combiner.gemspec
+++ b/sprockets-media_query_combiner.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.2'
 
-  gem.add_runtime_dependency "sprockets", "~>2.1"
+  gem.add_runtime_dependency "sprockets", ">= 2.1"
   gem.add_runtime_dependency "sass-media_query_combiner", "~>0.0.4"
 
   gem.add_development_dependency "rspec"

--- a/sprockets-media_query_combiner.gemspec
+++ b/sprockets-media_query_combiner.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.2'
 
-  gem.add_runtime_dependency "sprockets", ">= 2.1", "< 5.0"
+  gem.add_runtime_dependency "sprockets", ">= 2.1", "< 4.0"
   gem.add_runtime_dependency "sass-media_query_combiner", "~>0.0.4"
 
   gem.add_development_dependency "rspec"

--- a/sprockets-media_query_combiner.gemspec
+++ b/sprockets-media_query_combiner.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.2'
 
-  gem.add_runtime_dependency "sprockets", ">= 2.1", "< 4.0"
+  gem.add_runtime_dependency "sprockets", "~> 3.0"
   gem.add_runtime_dependency "sass-media_query_combiner", "~>0.0.4"
 
   gem.add_development_dependency "rspec"


### PR DESCRIPTION
Resumbitting pull request - Tilt issue is addressed now.

Support for all Sprockets versions is enabled.
If gem is used with fresh Sprockets, it uses native Sprockets processor, otherwise it switches back to Tilt.
Tests refactored to reflect last changes.

All tests pass.